### PR TITLE
Update default mappings table to match actual mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Plug 'roginfarrer/vim-dirvish-dovish', {'branch': 'main'}
 
 | Function                                | Default | Key                               |
 | --------------------------------------- | ------- | --------------------------------- |
-| Create file                             | `i`     | `<Plug>(dovish_create_file)`      |
-| Create directory                        | `I`     | `<Plug>(dovish_create_directory)` |
+| Create file                             | `a`     | `<Plug>(dovish_create_file)`      |
+| Create directory                        | `A`     | `<Plug>(dovish_create_directory)` |
 | Delete under cursor                     | `dd`    | `<Plug>(dovish_delete)`           |
 | Rename under cursor                     | `r`     | `<Plug>(dovish_rename)`           |
 | Yank under cursor (or visual selection) | `yy`    | `<Plug>(dovish_yank)`             |


### PR DESCRIPTION
Hi, it's a really small thing but I noticed the table of default mappings seems to not to match the actual mappings for creating new files and directories. It confused me for a minute or two when I first used it, so maybe the readme could be updated.

Thanks a lot for creating the plugin! I had been getting by using some much rougher wrappers around Shdo, so dovish should save a lot of time. 