### PR TITLE
Fix: buffer reload after copy/move to dir

### DIFF
--- a/ftplugin/dirvish.vim
+++ b/ftplugin/dirvish.vim
@@ -41,7 +41,7 @@ function! s:createFile() abort
   endif
 
   " Reload the buffer
-  normal R
+  Dirvish %
 endf
 
 function! s:createDirectory() abort
@@ -61,7 +61,8 @@ function! s:createDirectory() abort
     call s:logError(output)
   endif
 
-  normal R
+  " Reload the buffer
+  Dirvish %
 endf
 
 function! s:deleteItemUnderCursor() abort
@@ -73,8 +74,9 @@ function! s:deleteItemUnderCursor() abort
   if v:shell_error
     call s:logError(output)
   endif
+
   " Reload the buffer
-  normal R
+  Dirvish %
 endfunction
 
 function! s:renameItemUnderCursor() abort
@@ -86,7 +88,9 @@ function! s:renameItemUnderCursor() abort
   if v:shell_error
     call s:logError(output)
   endif
-  normal R
+
+  " Reload the buffer
+  Dirvish %
 endfunction
 
 function! s:isPreviouslyYankedItemValid() abort
@@ -149,7 +153,9 @@ function! s:moveYankedItemToCurrentDirectory() abort
       call s:logError(output)
     endif
   endfor
-  norm! R
+
+  " Reload the buffer
+  Dirvish %
 endfunction
 
 function! s:copyYankedItemToCurrentDirectory() abort
@@ -193,7 +199,8 @@ function! s:copyYankedItemToCurrentDirectory() abort
     endif
   endfor
 
-  norm! R
+  " Reload the buffer
+  Dirvish %
 endfunction
 
 function! s:copyFilePathUnderCursor() abort


### PR DESCRIPTION
Hi, I noticed that the buffer didn't seem to reload after moving/copying a file to a dir, I think because `norm!` was  used instead of `norm`. I actually changed norm completely to call `Dirvish %` instead, since I'm worried about what will happen if someone has changed their dirvish maps away from the defaults. 

It's working for me now, and I wondered if you might want the same updates so I've opened a PR. But feel free to edit/reject as you see fit!

Details:
- Previously the buffer did not reload after moving/copying a file to a dir,
  because norm! was used instead of norm.
- Instead of normal R, we now use Dirvish % to reload the buffer, in
  case the user has changed or overridden the dirvish maps.
