### PR TITLE
Move cursor to newly-created file or folder

### DIFF
--- a/ftplugin/dirvish.vim
+++ b/ftplugin/dirvish.vim
@@ -34,6 +34,10 @@ if !exists('g:DovishRename')
   endfunction
 end
 
+function! s:moveCursorTo(target)
+  call search('\V'.escape(a:target, '\\').'\$')
+endfunction
+
 " https://stackoverflow.com/a/47051271
 function! s:getVisualSelection()
   if mode()=="v"
@@ -72,6 +76,7 @@ function! s:createFile() abort
 
   " Reload the buffer
   Dirvish %
+  call s:moveCursorTo(filename)
 endf
 
 function! s:createDirectory() abort
@@ -93,6 +98,7 @@ function! s:createDirectory() abort
 
   " Reload the buffer
   Dirvish %
+  call s:moveCursorTo(dirname . '/')
 endf
 
 function! s:deleteItemUnderCursor() abort


### PR DESCRIPTION
This PR adds a simple, but in my opinion very useful feature. 
After you create a new file or folder, the cursor is moved to the new line so you can press Enter to directly edit the file or enter the folder.

https://user-images.githubusercontent.com/543561/173052587-940c36cb-fb88-4740-b127-d0247ebc27f7.mp4

